### PR TITLE
wildfly-maven-plugin: don't add this to the build process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+### Changed
+ - Don't add the wildfly plugin to the build process in "skipped" mode. Leave it out entirely
+
 ## [1.6.0] - 2017-07-28
 ### Changed
  - Upgrade to use parent POM [1.6.0](https://github.com/CJSCommonPlatform/maven-parent-pom/releases/tag/release-1.6.0)

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,7 @@
     <description>Parent POM for the Microservices framework</description>
 
     <properties>
-        <plugins.maven.wildfly.version>1.0.2.Final</plugins.maven.wildfly.version>
-        <plugins.maven.wildfly.skip>true</plugins.maven.wildfly.skip>
+        <plugins.maven.wildfly.version>1.2.0.Alpha6</plugins.maven.wildfly.version>
 
         <cpp.repo.name>maven-framework-parent-pom</cpp.repo.name>
     </properties>
@@ -143,18 +142,6 @@
 
         <!-- Plugin configuration -->
         <plugins>
-
-            <!-- The WildFly plugin deploys your war to a local WildFly container -->
-            <!-- Skip modules by default. To enable a module configure the plugin for that specific module -->
-            <!-- To use, run: mvn package wildfly:deploy -->
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <configuration>
-                    <skip>${plugins.maven.wildfly.skip}</skip>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
- in the microservice framework it's only used in example-it so why
  have it enabled for each and every module?