### PR TITLE
Framework E (17.104.x): Java 21 / WildFly 32 / Jakarta EE 10 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
-## [17.105.0-M1] - 2026-02-03
+## [21.0.0-SNAPSHOT] - 2026-03-26
 ### Changed
-- `skipTests` should skip liquibase apply step
+- Upgraded to Java 21 and Jakarta EE 10
+- Updated WildFly Maven plugin from `1.2.0.Final` to `4.2.2.Final`
+- Added `exec-maven-plugin` `3.0.0` to `pluginManagement`
+- Added `jandex-index` profile: auto-generates `META-INF/jandex.idx` via `io.smallrye:jandex:3.1.6` CLI during `process-classes` for all modules with `src/main/java` — required for WildFly to scan annotations in WEB-INF/lib JARs when deployed without `web.xml`
+
 
 ## [17.103.0] - 2025-07-11
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,53 @@
-# Framework Parent POM
+# cp-maven-framework-parent-pom
 
-The parent Maven POM for all Common Platform framework projects. It defines Maven configuration that
-should be consistent across all framework components.
+`uk.gov.justice:maven-framework-parent-pom`
+
+The Maven parent POM for all CPP framework implementation projects. It sits between `maven-parent-pom` (build tooling) and the framework code projects, adding the framework-specific build plugins and importing `maven-common-bom` so that dependency versions are available everywhere.
+
+## Position in the hierarchy
+
+```
+maven-parent-pom
+└── maven-framework-parent-pom  ← this project
+    ├── cp-framework-libraries   (uk.gov.justice.framework.libraries:framework-libraries)
+    ├── cp-microservice-framework (uk.gov.justice.services:microservice-framework)
+    ├── cp-event-store           (uk.gov.justice.event-store:event-store)
+    └── cp-cake-shop             (uk.gov.justice.services:cake-shop)
+```
+
+## What this POM adds
+
+**Dependency import**
+- Imports `maven-common-bom` so all third-party dependency versions are available to inheriting projects without re-declaring the import.
+
+**Additional plugin management**
+| Plugin | Purpose |
+|---|---|
+| `wildfly-maven-plugin` 4.2.2.Final | Deploy WARs to a running WildFly instance |
+| `liquibase-maven-plugin` 4.10.0 | Run Liquibase migrations (skipped when `skipTests=true`) |
+| `h2-maven-plugin` 1.0 | Embedded H2 database for tests |
+| `exec-maven-plugin` 3.0.0 | Execute external processes during build |
+| `maven-processor-plugin` (Hibernate JPA model gen) | Generates JPA metamodel classes |
+
+**Profiles**
+| Profile | Activation | Effect |
+|---|---|---|
+| `raml-jar` | `src/raml` exists | Packages RAML sources into a `raml` classifier JAR (plus early `generate-test-resources` phase copy for tests) |
+| `liquibase-jar` | `src/main/resources/liquibase.properties` exists | Runs Liquibase plugin, creates an executable shaded JAR for migration tooling |
+| `jandex-index` | `src/main/java` exists | Generates a Jandex index (`META-INF/jandex.idx`) for CDI bean discovery in WildFly |
+
+**JaCoCo exclusions** — generated classes excluded from coverage: `*Application`, `*JmsListener`, `Remote*`, `*Resource`, `*ActionMapper`, `*MediaTypeToSchemaIdMapper`, JPA entity metamodels.
+
+## Usage
+
+Set this as the `<parent>` in any new framework-layer project:
+
+```xml
+<parent>
+    <groupId>uk.gov.justice</groupId>
+    <artifactId>maven-framework-parent-pom</artifactId>
+    <version>${framework.version}</version>
+</parent>
+```
+
+Context-level services (`cpp-context-*`) do **not** use this POM directly — they inherit from `cpp-platform-maven-service-parent-pom` instead.

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -31,7 +31,7 @@ resources:
 pool:
   name: 'MDV-ADO-AGENT-AKS-01'
   demands:
-    - identifier -equals centos8-j17-postgres
+    - identifier -equals ubuntu-j21
  
 variables:
   - name: sonarqubeProject

--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-parent-pom</artifactId>
-        <version>21.0.0-SNAPSHOT</version>
+        <version>21.0.0-M1</version>
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
-    <version>21.0.0-SNAPSHOT</version>
+    <version>21.0.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Framework parent POM</name>
     <description>Parent POM for the Microservices framework</description>
@@ -22,6 +22,7 @@
         <plugins.exec-maven.version>3.0.0</plugins.exec-maven.version>
         <jandex.version>3.1.6</jandex.version>
         <cpp.repo.name>maven-framework-parent-pom</cpp.repo.name>
+        <maven.common.bom.version>21.0.0-M1</maven.common.bom.version>
     </properties>
 
     <scm>
@@ -35,7 +36,7 @@
             <dependency>
                 <groupId>uk.gov.justice</groupId>
                 <artifactId>maven-common-bom</artifactId>
-                <version>21.0.0-SNAPSHOT</version>
+                <version>${maven.common.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,17 +7,20 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-parent-pom</artifactId>
-        <version>17.103.0</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
-    <version>17.105.0-M2-SNAPSHOT</version>
+    <version>21.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Framework parent POM</name>
     <description>Parent POM for the Microservices framework</description>
 
     <properties>
-        <plugins.maven.wildfly.version>1.2.0.Final</plugins.maven.wildfly.version>
+        <plugins.maven.wildfly.version>4.2.2.Final</plugins.maven.wildfly.version>
+        <plugins.h2-maven.version>1.0</plugins.h2-maven.version>
+        <plugins.exec-maven.version>3.0.0</plugins.exec-maven.version>
+        <jandex.version>3.1.6</jandex.version>
         <cpp.repo.name>maven-framework-parent-pom</cpp.repo.name>
     </properties>
 
@@ -26,6 +29,18 @@
         <developerConnection>${cpp.scm.developerConnection}</developerConnection>
         <url>${cpp.scm.url}</url>
     </scm>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>uk.gov.justice</groupId>
+                <artifactId>maven-common-bom</artifactId>
+                <version>21.0.0-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <!--
     =====
@@ -58,7 +73,7 @@
                 <plugin>
                     <groupId>com.edugility</groupId>
                     <artifactId>h2-maven-plugin</artifactId>
-                    <version>1.0</version>
+                    <version>${plugins.h2-maven.version}</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.h2database</groupId>
@@ -94,6 +109,12 @@
                             <version>${hibernate.version}</version>
                         </dependency>
                     </dependencies>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${plugins.exec-maven.version}</version>
                 </plugin>
 
                 <plugin>
@@ -208,6 +229,21 @@
                                     </includes>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>raml-test</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <phase>generate-test-resources</phase>
+                                <configuration>
+                                    <classifier>raml</classifier>
+                                    <classesDirectory>${project.basedir}/src</classesDirectory>
+                                    <includes>
+                                        <include>raml/**</include>
+                                    </includes>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
@@ -266,24 +302,55 @@
                 <dependency>
                     <groupId>org.liquibase</groupId>
                     <artifactId>liquibase-core</artifactId>
-                    <version>${liquibase.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.postgresql</groupId>
                     <artifactId>postgresql</artifactId>
-                    <version>${postgresql.driver.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.yaml</groupId>
                     <artifactId>snakeyaml</artifactId>
-                    <version>${snakeyaml.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>info.picocli</groupId>
                     <artifactId>picocli</artifactId>
-                    <version>${picocli.version}</version>
                 </dependency>
             </dependencies>
+        </profile>
+
+        <profile>
+            <id>jandex-index</id>
+            <activation>
+                <file>
+                    <exists>src/main/java</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-jandex-index</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>java</executable>
+                                    <arguments>
+                                        <argument>-jar</argument>
+                                        <argument>${settings.localRepository}/io/smallrye/jandex/${jandex.version}/jandex-${jandex.version}.jar</argument>
+                                        <argument>-m</argument>
+                                        <argument>${project.build.outputDirectory}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
     </profiles>


### PR DESCRIPTION
## Summary
Upgrades `cp-maven-framework-parent-pom` to Java 21 as part of the Framework E (17.104.x) release line backport of the Java 21 / WildFly 32 / Jakarta EE 10 upgrade.

## Related
Framework E docs and status: https://github.com/hmcts/java-21-wildfly-32-updgrade-pilot-cpp-framework