### PR TITLE
Ensure jandex JAR is downloaded before exec plugin runs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,13 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.smallrye</groupId>
+                                <artifactId>jandex</artifactId>
+                                <version>${jandex.version}</version>
+                            </dependency>
+                        </dependencies>
                         <executions>
                             <execution>
                                 <id>generate-jandex-index</id>


### PR DESCRIPTION
## Summary

Adds `io.smallrye:jandex` as a dependency of the `exec-maven-plugin` in the `jandex-index` profile.

The exec plugin runs `java -jar ${settings.localRepository}/io/smallrye/jandex/.../jandex.jar` to generate Jandex indices. It assumed the JAR was already in the local Maven repository, but on a fresh cache (e.g. after a pom.xml change invalidates the CI cache key) the JAR is never downloaded because no project explicitly declares it as a dependency.

Declaring it as a plugin dependency ensures Maven downloads it before the plugin executes.

## Impact

- Fixes `Error: Unable to access jarfile .../jandex-3.1.6.jar` on fresh CI agent caches
- No functional change — exec behaviour is identical once the JAR is present