### PR TITLE
Update CHANGELOG for 21.0.0-M1 and 21.0.0-M2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
-## [21.0.0-SNAPSHOT] - 2026-03-26
+## [21.0.0-M1] - 2026-06-02
 ### Changed
-- Upgraded to Java 21 and Jakarta EE 10
+- Upgraded to Java 21 and Jakarta EE 10 (17.104.x release line)
 - Updated WildFly Maven plugin from `1.2.0.Final` to `4.2.2.Final`
+- Added `jandex-index` profile: auto-generates `META-INF/jandex.idx` via `io.smallrye:jandex:3.1.6` during `process-classes` for all modules with `src/main/java` — required for WildFly 32 to scan CDI annotations in `WEB-INF/lib` JARs
+- Added `maven-common-bom` as an imported BOM in `dependencyManagement`; `maven.common.bom.version` property controls the imported version
 - Added `exec-maven-plugin` `3.0.0` to `pluginManagement`
-- Added `jandex-index` profile: auto-generates `META-INF/jandex.idx` via `io.smallrye:jandex:3.1.6` CLI during `process-classes` for all modules with `src/main/java` — required for WildFly to scan annotations in WEB-INF/lib JARs when deployed without `web.xml`
 
+### Fixed
+- Declared `io.smallrye:jandex` as an explicit dependency of the `exec-maven-plugin` in the `jandex-index` profile — previously the plugin assumed jandex was already in the local Maven repository, causing `Error: Unable to access jarfile .../jandex-3.1.6.jar` failures on CI agents with a fresh Maven cache
 
 ## [17.103.0] - 2025-07-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
-## [21.0.0-M1] - 2026-06-02
+## [21.0.0-M3] - 2026-06-02
 ### Changed
 - Upgraded to Java 21 and Jakarta EE 10 (17.104.x release line)
 - Updated WildFly Maven plugin from `1.2.0.Final` to `4.2.2.Final`

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <plugins.exec-maven.version>3.0.0</plugins.exec-maven.version>
         <jandex.version>3.1.6</jandex.version>
         <cpp.repo.name>maven-framework-parent-pom</cpp.repo.name>
-        <maven.common.bom.version>21.0.0-M1</maven.common.bom.version>
+        <maven.common.bom.version>21.0.0-M2</maven.common.bom.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Replaces stale Framework F spike entries with accurate 21.0.0-M1 (Java 21 upgrade, jandex profile) and 21.0.0-M2 (jandex CI download fix) changelog entries, consolidated into a single entry.