### PR TITLE
Java 25 / WildFly 40 spike: cp-maven-framework-parent-pom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
-## [21.0.0-SNAPSHOT] - 2026-03-26
+## [21.0.0-M1] - 2026-06-02
 ### Changed
-- Upgraded to Java 21 and Jakarta EE 10
+- Upgraded to Java 21 and Jakarta EE 10 (17.104.x release line)
 - Updated WildFly Maven plugin from `1.2.0.Final` to `4.2.2.Final`
+- Added `jandex-index` profile: auto-generates `META-INF/jandex.idx` via `io.smallrye:jandex:3.1.6` during `process-classes` for all modules with `src/main/java` — required for WildFly 32 to scan CDI annotations in `WEB-INF/lib` JARs
+- Added `maven-common-bom` as an imported BOM in `dependencyManagement`; `maven.common.bom.version` property controls the imported version
 - Added `exec-maven-plugin` `3.0.0` to `pluginManagement`
-- Added `jandex-index` profile: auto-generates `META-INF/jandex.idx` via `io.smallrye:jandex:3.1.6` CLI during `process-classes` for all modules with `src/main/java` — required for WildFly to scan annotations in WEB-INF/lib JARs when deployed without `web.xml`
 
+### Fixed
+- Declared `io.smallrye:jandex` as an explicit dependency of the `exec-maven-plugin` in the `jandex-index` profile — previously the plugin assumed jandex was already in the local Maven repository, causing `Error: Unable to access jarfile .../jandex-3.1.6.jar` failures on CI agents with a fresh Maven cache
 
 ## [17.103.0] - 2025-07-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
-## [21.0.0-M1] - 2026-06-02
+## [21.0.0-M3] - 2026-06-02
 ### Changed
 - Upgraded to Java 21 and Jakarta EE 10 (17.104.x release line)
 - Updated WildFly Maven plugin from `1.2.0.Final` to `4.2.2.Final`

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -31,7 +31,7 @@ resources:
 pool:
   name: 'MDV-ADO-AGENT-AKS-01'
   demands:
-    - identifier -equals ubuntu-j21
+    - identifier -equals ubuntu-j25-postgres
  
 variables:
   - name: sonarqubeProject

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
-    <version>21.0.0-M1</version>
+    <version>21.0.0-M2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Framework parent POM</name>
     <description>Parent POM for the Microservices framework</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
-    <version>21.0.0-M3</version>
+    <version>21.0.0-M4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Framework parent POM</name>
     <description>Parent POM for the Microservices framework</description>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <plugins.exec-maven.version>3.0.0</plugins.exec-maven.version>
         <jandex.version>3.1.6</jandex.version>
         <cpp.repo.name>maven-framework-parent-pom</cpp.repo.name>
-        <maven.common.bom.version>21.0.0-M1</maven.common.bom.version>
+        <maven.common.bom.version>21.0.0-M2</maven.common.bom.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,13 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.smallrye</groupId>
+                                <artifactId>jandex</artifactId>
+                                <version>${jandex.version}</version>
+                            </dependency>
+                        </dependencies>
                         <executions>
                             <execution>
                                 <id>generate-jandex-index</id>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
-    <version>21.0.0-M3-SNAPSHOT</version>
+    <version>21.0.0-M3</version>
     <packaging>pom</packaging>
     <name>Framework parent POM</name>
     <description>Parent POM for the Microservices framework</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
-    <version>21.0.0-M2-SNAPSHOT</version>
+    <version>21.0.0-M2</version>
     <packaging>pom</packaging>
     <name>Framework parent POM</name>
     <description>Parent POM for the Microservices framework</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
-    <version>21.0.0-M2</version>
+    <version>21.0.0-M3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Framework parent POM</name>
     <description>Parent POM for the Microservices framework</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,22 +7,22 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-parent-pom</artifactId>
-        <version>21.0.0-M1</version>
+        <version>25.104.0-M1</version>
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
-    <version>21.0.0-M4-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Framework parent POM</name>
     <description>Parent POM for the Microservices framework</description>
 
     <properties>
-        <plugins.maven.wildfly.version>4.2.2.Final</plugins.maven.wildfly.version>
+        <plugins.maven.wildfly.version>6.0.0.Final</plugins.maven.wildfly.version>
         <plugins.h2-maven.version>1.0</plugins.h2-maven.version>
         <plugins.exec-maven.version>3.0.0</plugins.exec-maven.version>
         <jandex.version>3.1.6</jandex.version>
         <cpp.repo.name>maven-framework-parent-pom</cpp.repo.name>
-        <maven.common.bom.version>21.0.0-M2</maven.common.bom.version>
+        <maven.common.bom.version>25.104.0-M1</maven.common.bom.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>21.0.0-M1</version>
     <packaging>pom</packaging>
     <name>Framework parent POM</name>
     <description>Parent POM for the Microservices framework</description>


### PR DESCRIPTION
## Java 25 / WildFly 40 spike — cp-maven-framework-parent-pom

Spike to prove viability of skipping Java 21 and going straight to **Java 25 / WildFly 40 / Jakarta EE 11**.

**Spike gate: cp-cake-shop integration tests — 42/42 passing ✅**

Version series: `25.104.0-M1-SNAPSHOT` — the middle number preserves the framework-E lineage (104), 25 = Java version.

### Changes
- Version bumped to `25.104.0-M1-SNAPSHOT`
- Parent updated to `cp-maven-parent-pom:25.104.0-M1-SNAPSHOT`
- WildFly Maven plugin version aligned to 6.0.0.Final (WildFly 40)

### ⚠️ CI
CIs will fail until Java 25 build pipelines are created. **Do not merge until CI is green.**

### Related PRs (full spike chain)
cp-maven-super-pom → cp-maven-parent-pom → cp-maven-common-bom → cp-maven-framework-parent-pom → cp-file-service → cp-wiremock-service → cp-framework-libraries → cp-microservice-framework → cp-event-store → cp-cake-shop