### PR TITLE
Centralise jakarta.xml.bind-api.raml.version and liquibase.maven.plugin.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,22 @@
         <jandex.version>3.1.6</jandex.version>
         <cpp.repo.name>maven-framework-parent-pom</cpp.repo.name>
         <maven.common.bom.version>25.104.0-M3</maven.common.bom.version>
+
+        <!--
+            jakarta.xml.bind-api is managed by the BOM at 4.0.0 (Jakarta EE 10,
+            namespace jakarta.xml.bind.*). The RAML parser (org.raml:raml-parser) and
+            coveralls-maven-plugin 4.3.0 use javax.xml.bind.* classes internally.
+            Those classes only exist in versions 2.x of jakarta.xml.bind-api (before the
+            EE 9 namespace change). From 3.0.0 onwards javax.xml.bind.* is no longer
+            provided. Any plugin that uses the RAML parser or coveralls-maven-plugin must
+            pin its runtime classpath to this version. DO NOT upgrade to 3.x or 4.x.
+        -->
+        <jakarta.xml.bind-api.raml.version>2.3.2</jakarta.xml.bind-api.raml.version>
+
+        <!-- liquibase-maven-plugin: 4.24–4.29 have mojo loading failures (LOG_FORMAT removed,
+             AbstractLogger API break); 4.30.0 restores the stable API. Pin separately from
+             ${liquibase.version} (library) which remains at 4.27.0 for runtime compatibility. -->
+        <liquibase.maven.plugin.version>4.30.0</liquibase.maven.plugin.version>
     </properties>
 
     <scm>
@@ -65,7 +81,7 @@
                 <plugin>
                     <groupId>org.liquibase</groupId>
                     <artifactId>liquibase-maven-plugin</artifactId>
-                    <version>${liquibase.version}</version>
+                    <version>${liquibase.maven.plugin.version}</version>
                     <configuration>
                         <skip>${skipTests}</skip>
                     </configuration>


### PR DESCRIPTION
## Summary

- Adds `jakarta.xml.bind-api.raml.version=2.3.2` to the framework parent pom, eliminating duplication across `cp-framework-libraries`, `cp-microservice-framework`, and `cp-event-store` root poms (child projects will remove their local copies once M4 is released)
- Adds `liquibase.maven.plugin.version=4.30.0` as a separate property from `${liquibase.version}` (the library). Versions 4.24–4.29 have mojo loading failures (LOG_FORMAT removed, AbstractLogger API break); 4.30.0 restores the stable API
- Updates the `liquibase-maven-plugin` pluginManagement entry to use `${liquibase.maven.plugin.version}` instead of `${liquibase.version}` (4.27.0 — one of the broken versions)

## Test plan

- [ ] `cp-maven-framework-parent-pom` builds clean: `mvn clean install`
- [ ] CI passes