### PR TITLE
Bump maven-common-bom M6 -> M7 (Artemis 2.54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+## [25.104.0-M8] - 2026-07-27
+### Changed
+- Bumped `maven.common.bom.version` to `25.104.0-M6` — picks up Jackson `2.21.5` (**CVE-2026-54515**) and the `org.junit:junit-bom` import.
+- Bumped parent `maven-parent-pom` to `25.104.0-M7` — removes the dead `buildnumber-maven-plugin` `useLatestCommittedRevision` parameter (build-warning fix).
+
 ## [25.104.0-M7] - 2026-06-18
 ### Changed
 - Bumped parent `maven-parent-pom` to `25.104.0-M5` — picks up `liquibase.version=5.0.3`

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
-    <version>25.104.0-M8-SNAPSHOT</version>
+    <version>25.104.0-M8</version>
     <packaging>pom</packaging>
     <name>Framework parent POM</name>
     <description>Parent POM for the Microservices framework</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-parent-pom</artifactId>
-        <version>25.104.0-M6</version>
+        <version>25.104.0-M7</version>
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
@@ -22,7 +22,7 @@
         <plugins.exec-maven.version>3.0.0</plugins.exec-maven.version>
         <jandex.version>3.1.6</jandex.version>
         <cpp.repo.name>maven-framework-parent-pom</cpp.repo.name>
-        <maven.common.bom.version>25.104.0-M5</maven.common.bom.version>
+        <maven.common.bom.version>25.104.0-M6</maven.common.bom.version>
 
         <!--
             jakarta.xml.bind-api is managed by the BOM at 4.0.0 (Jakarta EE 10,

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>maven-framework-parent-pom</artifactId>
-    <version>25.104.0-M8</version>
+    <version>25.104.0-M9-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Framework parent POM</name>
     <description>Parent POM for the Microservices framework</description>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <plugins.exec-maven.version>3.0.0</plugins.exec-maven.version>
         <jandex.version>3.1.6</jandex.version>
         <cpp.repo.name>maven-framework-parent-pom</cpp.repo.name>
-        <maven.common.bom.version>25.104.0-M6</maven.common.bom.version>
+        <maven.common.bom.version>25.104.0-M7</maven.common.bom.version>
 
         <!--
             jakarta.xml.bind-api is managed by the BOM at 4.0.0 (Jakarta EE 10,


### PR DESCRIPTION
Cascade step 2 (after cp-maven-common-bom M7): bump `maven.common.bom.version` M6 -> M7 so the framework chain carries the Artemis 2.54 client. Parent-pom builds green against common-bom M7.